### PR TITLE
fix: calculate the position of context-menu by activeLayer (fix #23)

### DIFF
--- a/src/js/contextmenu.js
+++ b/src/js/contextmenu.js
@@ -414,7 +414,7 @@ class ContextMenu {
 
     this.activeLayer = relatedLayer;
 
-    const position = getMousePosition(clickEvent, document.body || document.documentElement);
+    const position = getMousePosition(clickEvent, this.activeLayer.container);
 
     /* clickEvent's clientX, clientY */
     const [left, top] = position;


### PR DESCRIPTION
Calculate the position of context-menu to be shown by `activeLayer`.
* Request from: https://github.com/nhn/tui.tree/pull/59#issuecomment-603429038