### PR TITLE
register/unregister API change

### DIFF
--- a/src/js/contextmenu.js
+++ b/src/js/contextmenu.js
@@ -438,7 +438,7 @@ class ContextMenu {
 
   /**
    * Register context menu
-   * @param {string} selector - css selector for displaying contextmenu at secondary mouse button click
+   * @param {HTMLElement} target - target element for displaying contextmenu at secondary mouse button click
    * @param {function} callback - callback for each menu item clicked
    * @param {MenuItem[]} menuItems - {@link MenuItem} schema
    * @example
@@ -448,7 +448,7 @@ class ContextMenu {
    *   console.log(`${ev.type}ed ${cmd}.`);
    * }
    * 
-   * contextMenu.register('#folder', [
+   * contextMenu.register(document.querySelector('#folder'), [
    *   {title: 'Open'},
    *   {
    *     title: 'Create',
@@ -461,9 +461,7 @@ class ContextMenu {
    * 
    * // When click 'a File': "Create a file"
    */
-  register(selector, callback, menuItems) {
-    const target = document.querySelector(selector);
-
+  register(target, callback, menuItems) {
     if (!target) {
       return;
     }
@@ -483,12 +481,11 @@ class ContextMenu {
 
   /**
    * Unregister context menu
-   * @param {string} selector - css selector used for register context menu
+   * @param {HTMLElement} target - target used for register context menu
    * @returns {boolean} whether unregister is successful?
    */
-  unregister(selector) {
+  unregister(target) {
     const {layerMap} = this;
-    const target = document.querySelector(selector);
 
     if (!target) {
       return false;

--- a/test/contextmenu.spec.js
+++ b/test/contextmenu.spec.js
@@ -16,7 +16,7 @@ describe('ContextMenu component', () => {
   it('use selector for displaying context menu.', () => {
     const cm = new ContextMenu(document.querySelector('#flContainer'));
 
-    cm.register('#menu1', null, [
+    cm.register(document.querySelector('#menu1'), null, [
       {
         title: 'open'
       }
@@ -57,7 +57,7 @@ describe('ContextMenu component', () => {
   it('show context menus that only below of mouse cursor.', () => {
     const cm = new ContextMenu(document.querySelector('#flContainer'));
 
-    cm.register('#menu1', null, [
+    cm.register(document.querySelector('#menu1'), null, [
       {
         title: 'a',
         menu: [
@@ -104,7 +104,7 @@ describe('ContextMenu component', () => {
     const cm = new ContextMenu(document.querySelector('#flContainer')),
       callback = jasmine.createSpy('contextMenu');
 
-    cm.register('#menu1', callback, [
+    cm.register(document.querySelector('#menu1'), callback, [
       {
         title: 'open'
       }
@@ -126,13 +126,13 @@ describe('ContextMenu component', () => {
     const cm = new ContextMenu(document.querySelector('#flContainer')),
       callback = jasmine.createSpy('contextMenu');
 
-    cm.register('#menu1', callback, [
+    cm.register(document.querySelector('#menu1'), callback, [
       {
         title: 'open'
       }
     ]);
 
-    cm.unregister('#menu1');
+    cm.unregister(document.querySelector('#menu1'));
 
     expect(cm.layerMap._values.length).toBe(0);
     expect(document.querySelectorAll('.floating-layer').length).toBe(0);
@@ -144,7 +144,7 @@ describe('ContextMenu component', () => {
     beforeEach(() => {
       ce = new ContextMenu(document.querySelector('#flContainer'));
 
-      ce.register('#menu1', null, [
+      ce.register(document.querySelector('#menu1'), null, [
         {title: 'root-a'},
         {
           title: 'root-b',
@@ -187,7 +187,7 @@ describe('ContextMenu component', () => {
       cm = new ContextMenu(document.querySelector('#flContainer'));
       callback = jasmine.createSpy('contextMenu');
 
-      cm.register('#menu1', callback, [
+      cm.register(document.querySelector('#menu1'), callback, [
         {title: 'menu-disable1', disable: true},
         {title: 'menu-enable'},
         {title: 'menu-disable2', disable: true}


### PR DESCRIPTION
- first argument of register/unregister changed to HTMLElement
- allows user to pass in HTMLElement from inside a shadow DOM
- keeps API consistent since the constructor uses HTMLElement