### PR TITLE
fix: wrong position of context menu with browser scroll (fix #34)

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -20,6 +20,7 @@ When you select each menu, or click outside of the area where the menu closes.
 ## Write wrapper elements
 
 ```html
+<!-- Notice: The wrapper element must be located below the body. -->
 <!-- Tag to create the context menu -->
 <div id="tui-context-menu-container"></div>
 

--- a/src/js/contextmenu.js
+++ b/src/js/contextmenu.js
@@ -6,7 +6,6 @@
 import forEachArray from 'tui-code-snippet/collection/forEachArray';
 import off from 'tui-code-snippet/domEvent/off';
 import on from 'tui-code-snippet/domEvent/on';
-import getMousePosition from 'tui-code-snippet/domEvent/getMousePosition';
 import preventDefault from 'tui-code-snippet/domEvent/preventDefault';
 import addClass from 'tui-code-snippet/domUtil/addClass';
 import closest from 'tui-code-snippet/domUtil/closest';
@@ -19,7 +18,7 @@ import debounce from 'tui-code-snippet/tricks/debounce';
 
 import FloatingLayer from './floatingLayer';
 import Map from './Map';
-import {sendHostName} from './util';
+import {sendHostName, getMousePosition} from './util';
 import tmpl from '../template/contextmenu';
 
 const DEFAULT_ZINDEX = 999;
@@ -420,7 +419,7 @@ class ContextMenu {
 
     this.activeLayer = relatedLayer;
 
-    const {left, top} = this.getMousePosition(clickEvent);
+    const {left, top} = getMousePosition(clickEvent, this.activeLayer.container);
 
     const debouncedMouseMove = debounce(mouseMoveEvent => this._onMouseMove(mouseMoveEvent), opt.delay);
 
@@ -438,25 +437,6 @@ class ContextMenu {
     on(document, 'mousedown', this._onMouseDown, this);
     on(document, 'click', this._onMouseClick, this);
     on(document, 'scroll', this._onPageScroll, this);
-  }
-
-  /**
-   * Get mouse postion
-   * @param {MouseEvent} clickEvent - mouse event object
-   * @returns {Object} object of mouse position contains left and top
-   * @private
-   */
-  getMousePosition(clickEvent) {
-    const position = getMousePosition(clickEvent, this.activeLayer.container);
-
-    /* clickEvent's clientX, clientY */
-    let [left, top] = position;
-    const {scrollLeft, scrollTop} = document.documentElement;
-
-    left += scrollLeft;
-    top += scrollTop;
-
-    return {left, top};
   }
 
   /**

--- a/src/js/contextmenu.js
+++ b/src/js/contextmenu.js
@@ -420,10 +420,8 @@ class ContextMenu {
 
     this.activeLayer = relatedLayer;
 
-    const position = getMousePosition(clickEvent, this.activeLayer.container);
+    const {left, top} = this.getMousePosition(clickEvent);
 
-    /* clickEvent's clientX, clientY */
-    const [left, top] = position;
     const debouncedMouseMove = debounce(mouseMoveEvent => this._onMouseMove(mouseMoveEvent), opt.delay);
 
     this.cloneMouseMoveEvent = function(mouseMoveEvent) {
@@ -440,6 +438,25 @@ class ContextMenu {
     on(document, 'mousedown', this._onMouseDown, this);
     on(document, 'click', this._onMouseClick, this);
     on(document, 'scroll', this._onPageScroll, this);
+  }
+
+  /**
+   * Get mouse postion
+   * @param {MouseEvent} clickEvent - mouse event object
+   * @returns {Object} object of mouse position contains left and top
+   * @private
+   */
+  getMousePosition(clickEvent) {
+    const position = getMousePosition(clickEvent, this.activeLayer.container);
+
+    /* clickEvent's clientX, clientY */
+    let [left, top] = position;
+    const {scrollLeft, scrollTop} = document.documentElement;
+
+    left += scrollLeft;
+    top += scrollTop;
+
+    return {left, top};
   }
 
   /**

--- a/src/js/util.js
+++ b/src/js/util.js
@@ -12,3 +12,15 @@ import sendHostname from 'tui-code-snippet/request/sendHostname';
 export const sendHostName = () => {
   sendHostname('context-menu', 'UA-129987462-1');
 };
+
+/**
+   * Get mouse postion
+   * @param {MouseEvent} clickEvent - mouse event object
+   * @returns {Object} object of mouse position contains left and top
+   * @private
+   */
+export const getMousePosition = clickEvent => {
+  const {pageX: left, pageY: top} = clickEvent;
+
+  return {left, top};
+};


### PR DESCRIPTION
<!-- EDIT TITLE PLEASE -->
<!-- It should be one of them
  <ISSUE TYPE>: Short Description (<CLOSING TYPE> #<ISSUE NUMBERS>)
  ex)
  feat: add new feature (close #111)
  fix: wrong behavior (fix #111)
  chore: change build tool (ref #111)
-->

<!-- SPECIFY A ISSUE TYPE AT HEAD
  feat: A new feature
  fix: A bug fix
  docs: Documentation only changes
  style: Changes that do not affect the meaning of the code (white-space, formatting etc)
  refactor: A code change that neither fixes a bug or adds a feature
  perf: A code change that improves performance
  test: Adding missing tests
  chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

<!-- ADD CLOSING TYPE AND ISSUE NUMBER AT TAIL
  (<CLOSING TYPE> #<ISSUE NUMBERS>)
  close: resolve not a bug(feature, docs, etc) completely
  fix: resolve a bug completely
  ref: not fully resolved or related to
-->

### Please check if the PR fulfills these requirements
- [x] It's the right issue type on the title
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [ ] It does not introduce a breaking change or has a description of the breaking change

### Description
* Context menu shows in correct position when browser scrolled (#43)

**as-is**
![image](https://user-images.githubusercontent.com/41339744/122153299-a0ece880-ce9d-11eb-8d9f-3fa5fec05bc7.gif)

**to-be**
![image](https://user-images.githubusercontent.com/41339744/122153349-bcf08a00-ce9d-11eb-9c6c-1fe98c873904.gif)

---
Thank you for your contribution to TOAST UI product. 🎉 😘 ✨


